### PR TITLE
fix: `once_cell` moved to `dev-deps`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,12 +12,14 @@ serde = ["dep:serde", "dep:serde_json"]
 clap = { version = "3.2.8", features = ["clap_derive", "derive"] }
 compact_str = { version = "0.5.1", features = ["serde"] }
 indexmap = "1.9.1"
-once_cell = "~1.12"
 rand = "0.8.5"
 rust_decimal = "1.25.0"
 serde = { version = "~1.0", features = ["derive"], optional = true }
 serde_json = { version = "~1.0", optional = true }
 thiserror = "1.0.31"
+
+[dev-dependencies]
+once_cell = "~1.12"
 
 [profile.release]
 lto = true


### PR DESCRIPTION
As long as `once_cell` is used only in tests, we can safetly move it to dev dependencies.