### PR TITLE
feat: moved `Orderbook` into `engine` mod

### DIFF
--- a/src/engine/engine.rs
+++ b/src/engine/engine.rs
@@ -1,5 +1,5 @@
-use super::{Event, Order, OrderId, OrderRequest, Trade};
-use crate::{Asset, Exchange, Orderbook};
+use super::{Event, Order, OrderId, OrderRequest, Orderbook, Trade};
+use crate::{Asset, Exchange};
 
 pub struct Engine {
     orderbook: Orderbook<Order, Event<Order>, Trade>,
@@ -24,9 +24,10 @@ impl Engine {
                 self.orderbook.matching(order)
             }
             OrderRequest::Delete { ref order_id } => {
-                if let Some(order) = self.orderbook.remove(&OrderId::new(
-                    order_id.parse::<u64>().unwrap(),
-                )) {
+                if let Some(order) = self
+                    .orderbook
+                    .remove(&OrderId::new(order_id.parse::<u64>().unwrap()))
+                {
                     vec![Event::Removed(order.id())]
                 } else {
                     vec![]

--- a/src/engine/mod.rs
+++ b/src/engine/mod.rs
@@ -7,6 +7,9 @@ pub use event::Event;
 mod order;
 pub use order::{AskOrder, BidOrder, Order};
 
+mod orderbook;
+pub use orderbook::Orderbook;
+
 mod order_id;
 pub use order_id::OrderId;
 

--- a/src/engine/orderbook.rs
+++ b/src/engine/orderbook.rs
@@ -7,8 +7,7 @@ use std::marker::PhantomData;
 use compact_str::CompactString;
 use indexmap::IndexMap;
 
-use crate::internals::ExchangeExt;
-use crate::{Asset, Exchange, ExchangeEvent, OrderSide};
+use crate::{Asset, Exchange, ExchangeEvent, ExchangeExt, OrderSide};
 
 pub struct Orderbook<Order: Asset, Event, Trade> {
     #[allow(dead_code)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,4 @@ pub use crate::internals::{
 mod order_side;
 pub use crate::order_side::OrderSide;
 
-mod orderbook;
-pub use crate::orderbook::Orderbook;
-
 pub mod engine;


### PR DESCRIPTION
Let only generic entities in top-level module.